### PR TITLE
Improve Glyphmap memory usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   Font class included in public API.
+-   Glyphmap with dynamic font demo.
+
 ## [0.2.0] - 2022-01-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   Font class included in public API.
 -   Glyphmap with dynamic font demo.
+-   Glyphset internal class for use in managing textures for Glyphmap - improve Glyphmap refresh performance.
+
+### Changed
+
+-   Glyphmap uses Glyphset internally and in renderers.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   Font class included in public API.
 -   Glyphmap with dynamic font demo.
 
+### Removed
+
+-   Remove extraneous glyph data from glyphmap instance; use texture keys to reconstitute glyph data when refreshing.
+
 ## [0.2.0] - 2022-01-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Phaser 3 glyph plugin. Inspired by [rot.js](https://ondras.github.io/rot.js/hp/)
             for (let y = 0; y < glyphmap.heightInCells; ++y) {
                 for (let x = 0; x < glyphmap.widthInCells; ++x) {
                     if (!y || !x || y === glyphmap.heightInCells - 1 || x === glyphmap.widthInCells - 1) {
-                        glyphmap.set(x, y, [['#', '#EEEEEEFE', '#4444']]);
+                        glyphmap.draw(x, y, [['#', '#EEEEEEFE', '#4444']]);
                     } else {
-                        glyphmap.set(x, y, [['.', '#FFF']]);
+                        glyphmap.draw(x, y, [['.', '#FFF']]);
                     }
                 }
             }
@@ -82,7 +82,7 @@ npm start
 Live development with demos:
 
 ```shell
-npm run start-demos
+npm run demos
 ```
 
 Lint files:

--- a/demos/glyphmap-3/index.ts
+++ b/demos/glyphmap-3/index.ts
@@ -1,0 +1,71 @@
+import { demoHandlerFactory, getParams } from '../shared';
+import type { Glyphmap } from '../../src';
+
+export default demoHandlerFactory(async (config) => {
+  const api = await import(/* webpackChunkName: "phaser-glyph-plugin" */ '../../src');
+
+  const params = getParams();
+
+  const forceSquareRatio = params.square === 'true' ? true : false;
+
+  class Scene extends api.GlyphPlugin.GlyphScene('glyph', class extends Phaser.Scene {}) {
+    map: Glyphmap;
+
+    marker: Phaser.GameObjects.Graphics;
+
+    create() {
+      this.map = this.add.glyphmap(333, 47.2, 25, 15, undefined, forceSquareRatio);
+
+      this.marker = this.add.graphics();
+      this.marker.lineStyle(2, 0xffff00, 1);
+      this.marker.strokeRect(0, 0, this.map.cellWidth * this.map.scaleX, this.map.cellHeight * this.map.scaleY);
+
+      for (let y = 0; y < this.map.heightInCells; ++y) {
+        for (let x = 0; x < this.map.widthInCells; ++x) {
+          if (!y || !x || y === this.map.heightInCells - 1 || x === this.map.widthInCells - 1) {
+            this.map.draw(x, y, [['#', '#EEEEEEFE', '#4444']]);
+          } else {
+            this.map.draw(x, y, [['.', '#FFF']]);
+          }
+        }
+      }
+
+      this.cameras.main.centerOn(this.map.getCenter().x, this.map.getCenter().y);
+
+      this.time.addEvent({
+        loop: true,
+        delay: 3000,
+        callback: () => {
+          this.map.setFont(new api.Font(Phaser.Math.RND.integerInRange(20, 36), 'monospace'));
+          this.marker.clear();
+          this.marker.lineStyle(2, 0xffff00, 1);
+          this.marker.strokeRect(0, 0, this.map.cellWidth * this.map.scaleX, this.map.cellHeight * this.map.scaleY);
+          this.cameras.main.centerOn(this.map.getCenter().x, this.map.getCenter().y);
+        },
+        callbackScope: this
+      });
+    }
+
+    update() {
+      const worldPoint = this.input.activePointer.positionToCamera(this.cameras.main) as Phaser.Math.Vector2;
+
+      // Rounds down to nearest cell.
+      const pointerCellX = this.map.worldToCellX(worldPoint.x);
+      const pointerCellY = this.map.worldToCellY(worldPoint.y);
+
+      // Snap to cell coordinates, but in world space.
+      this.marker.x = this.map.cellToWorldX(pointerCellX);
+      this.marker.y = this.map.cellToWorldY(pointerCellY);
+
+      if (this.input.manager.activePointer.isDown) {
+        this.map.draw(pointerCellX, pointerCellY, [
+          [Phaser.Math.RND.integerInRange(20, 200), Phaser.Display.Color.RandomRGB(), Phaser.Display.Color.RandomRGB()]
+        ]);
+      }
+    }
+  }
+
+  (config.scene as typeof Scene[]).push(Scene);
+
+  new Phaser.Game(config);
+});

--- a/demos/index.ts
+++ b/demos/index.ts
@@ -17,6 +17,12 @@ const demos = [
     'Input handling with Glyphmap',
     async (...args: DemoArgs) =>
       (await import(/* webpackChunkName: "demo-glyphmap-2" */ './glyphmap-2')).default(...args)
+  ],
+  [
+    'glyphmap-3',
+    'Dynamic font with Glyphmap',
+    async (...args: DemoArgs) =>
+      (await import(/* webpackChunkName: "demo-glyphmap-3" */ './glyphmap-3')).default(...args)
   ]
 ] as const;
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "postinstall": "husky install",
     "start": "jest --watch",
-    "start-demos": "cross-env DEMOS=true webpack-dev-server --progress --color",
     "test": "jest --coverage",
+    "demos": "cross-env DEMOS=true webpack-dev-server --progress --color",
     "prebuild": "cavy clean dist",
     "build": "npm run build-bundle && npm run build-canvas-bundle && npm run build-webgl-bundle && npm run build-js",
     "postbuild": "cavy copy dist && shx cp LICENSE README.md dist",

--- a/src/gameobjects/glyphmap.spec.ts
+++ b/src/gameobjects/glyphmap.spec.ts
@@ -282,7 +282,7 @@ describe('Glyphmap', () => {
     const input = new Glyphmap(scene);
 
     const actual = (() => {
-      const spy = jest.spyOn(input['glyphs'], 'clear');
+      const spy = jest.spyOn(input['textures'], 'clear');
       input.clear().destroy();
       return spy;
     })();
@@ -297,7 +297,7 @@ describe('Glyphmap', () => {
 
     const actual = (() => {
       const glyphmap = new Glyphmap(scene);
-      const spy = jest.spyOn(glyphmap['glyphs'], 'delete');
+      const spy = jest.spyOn(glyphmap['textures'], 'delete');
       glyphmap.erase(...input).destroy();
       return spy;
     })();
@@ -312,7 +312,7 @@ describe('Glyphmap', () => {
 
     const actual = (() => {
       const glyphmap = new Glyphmap(scene);
-      const spy = jest.spyOn(glyphmap['glyphs'], 'set');
+      const spy = jest.spyOn(glyphmap['textures'], 'set');
       glyphmap.draw(...input).destroy();
       return spy;
     })();
@@ -349,7 +349,7 @@ describe('Glyphmap', () => {
 
     const actual = (() => {
       const glyphmap = new Glyphmap(scene);
-      const spy = jest.spyOn(glyphmap['glyphs'], 'set');
+      const spy = jest.spyOn(glyphmap['textures'], 'set');
       glyphmap.draw(...input).destroy();
       return spy;
     })();

--- a/src/gameobjects/glyphmap.spec.ts
+++ b/src/gameobjects/glyphmap.spec.ts
@@ -1,7 +1,7 @@
 import { GlyphPlugin } from '../plugin';
 import { Font, GlyphLike } from '../shared';
 
-import { Glyphmap } from './glyphmap';
+import { Glyphmap, Glyphset } from './glyphmap';
 
 describe('Glyphmap', () => {
   let game: Phaser.Game;
@@ -42,9 +42,9 @@ describe('Glyphmap', () => {
     const input = new Glyphmap(scene);
 
     const actual = (() => {
-      const ok = input instanceof Glyphmap;
+      const result = input instanceof Glyphmap;
       input.destroy();
-      return ok;
+      return result;
     })();
 
     const expected = true;
@@ -122,13 +122,13 @@ describe('Glyphmap', () => {
         ['R', '#aaa'],
         ['T', '#aaa']
       ]);
-      const spy = jest.spyOn(glyphmap['textures'], 'set');
+      const spy = jest.spyOn(glyphmap['glyphset'], 'update');
       glyphmap.font = input;
       glyphmap.destroy();
       return spy;
     })();
 
-    const expected = 2;
+    const expected = 1;
 
     expect(actual).toHaveBeenCalledTimes(expected);
   });
@@ -183,13 +183,13 @@ describe('Glyphmap', () => {
         ['R', '#aaa'],
         ['T', '#aaa']
       ]);
-      const spy = jest.spyOn(glyphmap['textures'], 'set');
+      const spy = jest.spyOn(glyphmap['glyphset'], 'update');
       glyphmap.forceSquareRatio = input;
       glyphmap.destroy();
       return spy;
     })();
 
-    const expected = 2;
+    const expected = 1;
 
     expect(actual).toHaveBeenCalledTimes(expected);
   });
@@ -246,13 +246,13 @@ describe('Glyphmap', () => {
         ['R', '#aaa'],
         ['T', '#aaa']
       ]);
-      const spy = jest.spyOn(glyphmap['textures'], 'set');
+      const spy = jest.spyOn(glyphmap['glyphset'], 'update');
       glyphmap.glyphPlugin = input;
       glyphmap.destroy();
       return spy;
     })();
 
-    const expected = 2;
+    const expected = 1;
 
     expect(actual).toHaveBeenCalledTimes(expected);
     input.destroy();
@@ -282,7 +282,7 @@ describe('Glyphmap', () => {
     const input = new Glyphmap(scene);
 
     const actual = (() => {
-      const spy = jest.spyOn(input['textures'], 'clear');
+      const spy = jest.spyOn(input['mapData'], 'clear');
       input.clear().destroy();
       return spy;
     })();
@@ -297,7 +297,8 @@ describe('Glyphmap', () => {
 
     const actual = (() => {
       const glyphmap = new Glyphmap(scene);
-      const spy = jest.spyOn(glyphmap['textures'], 'delete');
+      glyphmap.draw(0, 0, [['#', '#483']]);
+      const spy = jest.spyOn(glyphmap['mapData'], 'delete');
       glyphmap.erase(...input).destroy();
       return spy;
     })();
@@ -312,7 +313,7 @@ describe('Glyphmap', () => {
 
     const actual = (() => {
       const glyphmap = new Glyphmap(scene);
-      const spy = jest.spyOn(glyphmap['textures'], 'set');
+      const spy = jest.spyOn(glyphmap['mapData'], 'set');
       glyphmap.draw(...input).destroy();
       return spy;
     })();
@@ -349,7 +350,7 @@ describe('Glyphmap', () => {
 
     const actual = (() => {
       const glyphmap = new Glyphmap(scene);
-      const spy = jest.spyOn(glyphmap['textures'], 'set');
+      const spy = jest.spyOn(glyphmap['mapData'], 'set');
       glyphmap.draw(...input).destroy();
       return spy;
     })();
@@ -875,6 +876,156 @@ describe('Glyphmap', () => {
 
       expect(actual).toHaveBeenCalledTimes(expected);
       actual.mockReset();
+    });
+  });
+
+  describe('Glyphset', () => {
+    it('instantiates', () => {
+      const input = new Glyphset();
+      const actual = input instanceof Glyphset;
+      const expected = true;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('adds a texture', () => {
+      const input = game.textures.createCanvas('0x00000000000000000000');
+
+      const actual = (() => {
+        const glyphset = new Glyphset();
+        const id = glyphset.add(input);
+        input.destroy();
+        return id;
+      })();
+
+      const expected = 1;
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('adds the same texture multiple times, uses same id & tracks count', () => {
+      const input = game.textures.createCanvas('0x00000000000000000000');
+
+      const actual = (() => {
+        const glyphset = new Glyphset();
+        const spy = jest.spyOn(glyphset['idCounts'], 'set');
+        glyphset.add(input);
+        const id = glyphset.add(input);
+        input.destroy();
+        return [id, spy];
+      })();
+
+      const expected = [1, 3];
+
+      expect(actual[0]).toEqual(expected[0]);
+      expect(actual[1]).toHaveBeenCalledTimes(expected[1]);
+    });
+
+    it('clears textures', () => {
+      const input = game.textures.createCanvas('0x00000000000000000000');
+
+      const actual = (() => {
+        const glyphset = new Glyphset();
+        const spy = jest.spyOn(glyphset['textures'], 'clear');
+        glyphset.add(input);
+        glyphset.clear();
+        input.destroy();
+        return spy;
+      })();
+
+      const expected = 1;
+
+      expect(actual).toHaveBeenCalledTimes(expected);
+    });
+
+    it('gets texture', () => {
+      const input = game.textures.createCanvas('0x00000000000000000000');
+
+      const actual = (() => {
+        const glyphset = new Glyphset();
+        const id = glyphset.add(input);
+        return glyphset.get(id);
+      })();
+
+      const expected = input;
+
+      expect(actual).toEqual(expected);
+      input.destroy();
+    });
+
+    it('checks for texture', () => {
+      const input = game.textures.createCanvas('0x00000000000000000000');
+
+      const actual = (() => {
+        const glyphset = new Glyphset();
+        const results: boolean[] = [];
+        results.push(glyphset.has(1));
+        glyphset.add(input);
+        results.push(glyphset.has(1));
+        input.destroy();
+        return results;
+      })();
+
+      const expected = [false, true];
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('does nothing when removing with an unknown id', () => {
+      const input = 17;
+
+      const actual = (() => {
+        const glyphset = new Glyphset();
+        const spy = jest.spyOn(glyphset['idCounts'], 'get');
+        glyphset.remove(input);
+        return spy;
+      })();
+
+      const expected = 0;
+
+      expect(actual).toHaveBeenCalledTimes(expected);
+    });
+
+    it('removes the same texture multiple times & tracks count', () => {
+      const input = game.textures.createCanvas('0x00000000000000000000');
+
+      const actual = (() => {
+        const glyphset = new Glyphset();
+        glyphset.add(input);
+        const id = glyphset.add(input);
+        const deleteSpy = jest.spyOn(glyphset['textures'], 'delete');
+        const setSpy = jest.spyOn(glyphset['idCounts'], 'set');
+        glyphset.remove(id).remove(id);
+        input.destroy();
+        return [deleteSpy, setSpy];
+      })();
+
+      const expected = [1, 1];
+
+      expect(actual[0]).toHaveBeenCalledTimes(expected[0]);
+      expect(actual[1]).toHaveBeenCalledTimes(expected[1]);
+    });
+
+    it('updates textures', () => {
+      const input = [
+        game.textures.createCanvas('0x00000000000000000000'),
+        game.textures.createCanvas('0x00000000000000000001')
+      ] as const;
+
+      const actual = (() => {
+        const glyphset = new Glyphset();
+        glyphset.add(input[0]);
+        glyphset.add(input[1]);
+        const spy = jest.spyOn(glyphset['textures'], 'set');
+        glyphset.update(game.plugins.get('GlyphPlugin') as GlyphPlugin, new Font(24, 'monospace'), false);
+        input[0].destroy();
+        input[1].destroy();
+        return spy;
+      })();
+
+      const expected = 2;
+
+      expect(actual).toHaveBeenCalledTimes(expected);
     });
   });
 });

--- a/src/gameobjects/glyphmap.ts
+++ b/src/gameobjects/glyphmap.ts
@@ -31,7 +31,7 @@ import { CustomGameObject } from '@agogpixel/phaser3-ts-utils/mixins/gameobjects
 
 import { GlyphPlugin, GlyphPluginEvent } from '../plugin';
 import { convertHexStringToBuffer, GlyphLike } from '../shared';
-import { bytesPerGlyph, createGlyphsBuffer, Font } from '../shared';
+import { Font } from '../shared';
 
 /**
  * Glyphmap factory type.
@@ -211,7 +211,8 @@ if (typeof WEBGL_RENDERER) {
     const halfWidth = cellWidth * 0.5;
     const halfHeight = cellHeight * 0.5;
 
-    const textures = src['textures'];
+    const mapData = src['mapData'];
+    const glyphset = src['glyphset'];
     const getKey = Glyphmap['getKey'];
 
     renderer.pipelines.preBatch(src);
@@ -220,15 +221,15 @@ if (typeof WEBGL_RENDERER) {
       for (let indexX = cullBoundsX; indexX < cullBoundsEndX; ++indexX) {
         const key = getKey(indexX, indexY);
 
-        if (!textures.has(key)) {
+        if (!mapData.has(key)) {
           continue;
         }
 
-        const cellTextures = textures.get(key);
-        const cellTexturesLen = cellTextures.length;
+        const cellTextureIds = mapData.get(key);
+        const cellTextureIdsLen = cellTextureIds.length;
 
-        for (let ix = 0; ix < cellTexturesLen; ++ix) {
-          const texture = cellTextures[ix].get().source.glTexture;
+        for (let ix = 0; ix < cellTextureIdsLen; ++ix) {
+          const texture = glyphset.get(cellTextureIds[ix]).get().source.glTexture;
 
           const textureUnit = pipeline.setTexture2D(texture);
           const tint = getTint(0xffffff, alpha);
@@ -342,25 +343,26 @@ if (typeof CANVAS_RENDERER) {
     const halfWidth = cellWidth * 0.5;
     const halfHeight = cellHeight * 0.5;
 
-    const textures = src['textures'];
+    const mapData = src['mapData'];
+    const glyphset = src['glyphset'];
     const getKey = Glyphmap['getKey'];
 
     for (let y = cullBoundsY; y < cullBoundsEndY; ++y) {
       for (let x = cullBoundsX; x < cullBoundsEndX; ++x) {
         const key = getKey(x, y);
 
-        if (!textures.has(key)) {
+        if (!mapData.has(key)) {
           continue;
         }
 
         ctx.save();
         ctx.translate(x * cellWidth + halfWidth, y * cellHeight + halfHeight);
 
-        const cellTextures = textures.get(key);
-        const cellTexturesLen = cellTextures.length;
+        const cellTextureIds = mapData.get(key);
+        const cellTextureIdsLen = cellTextureIds.length;
 
-        for (let ix = 0; ix < cellTexturesLen; ++ix) {
-          const sourceImage = cellTextures[ix].getSourceImage() as HTMLImageElement | HTMLCanvasElement;
+        for (let ix = 0; ix < cellTextureIdsLen; ++ix) {
+          const sourceImage = glyphset.get(cellTextureIds[ix]).getSourceImage() as HTMLImageElement | HTMLCanvasElement;
 
           ctx.drawImage(
             sourceImage,
@@ -450,9 +452,14 @@ export class Glyphmap extends CustomGameObject(
   protected readonly renderWebGL = renderWebGL;
 
   /**
-   * Glyph texture data, mapping position key to glyph textures.
+   * Dynamically track & manage glyph textures.
    */
-  private readonly textures = new Map<string, Phaser.Textures.Texture[]>();
+  private readonly glyphset = new Glyphset();
+
+  /**
+   * Glyphmap data, mapping position key to glyph texture ids.
+   */
+  private readonly mapData = new Map<string, number[]>();
 
   /**
    * Track current glyph cell height, in pixels.
@@ -646,18 +653,27 @@ export class Glyphmap extends CustomGameObject(
    * @returns Glyphmap instance for further chaining.
    */
   clear() {
-    this.textures.clear();
+    this.mapData.clear();
+    this.glyphset.clear();
     return this;
   }
 
   /**
    * Erase glyphs at specified cell position.
-   * @param x
-   * @param y
+   * @param x Cell X-coordinate.
+   * @param y Cell Y-coordinate.
    * @returns Glyphmap instance for further chaining.
    */
   erase(x: number, y: number) {
-    this.textures.delete(Glyphmap.getKey(x, y));
+    const key = Glyphmap.getKey(x, y);
+
+    if (!this.mapData.has(key)) {
+      return this;
+    }
+
+    this.mapData.get(key).forEach((id) => this.glyphset.remove(id));
+    this.mapData.delete(key);
+
     return this;
   }
 
@@ -692,12 +708,13 @@ export class Glyphmap extends CustomGameObject(
     const key = Glyphmap.getKey(x, y);
 
     const glyphPlugin = this.glyphPlugin;
+    const glyphset = this.glyphset;
     const font = this.currentFont;
     const forceSquareRatio = this.currentForceSquareRatio;
 
-    this.textures.set(
+    this.mapData.set(
       key,
-      glyphs.map((glyph) => glyphPlugin.getTexture([glyph], font, forceSquareRatio))
+      glyphs.map((glyph) => glyphset.add(glyphPlugin.getTexture([glyph], font, forceSquareRatio)))
     );
 
     return this;
@@ -905,24 +922,151 @@ export class Glyphmap extends CustomGameObject(
    * @returns Glyphmap instance for further chaining.
    */
   private updateTextures() {
-    const font = this.currentFont;
-    const forceSquareRatio = this.currentForceSquareRatio;
+    this.glyphset.update(this.glyphPlugin, this.currentFont, this.currentForceSquareRatio);
+    return this;
+  }
+}
+
+/**
+ * Manages glyphmap textures.
+ * @internal
+ */
+export class Glyphset {
+  /**
+   * Read the first section of glyph texture key (hex string containing ch, fg, & bg data).
+   * @param texture Texture generated by a glyph plugin.
+   * @returns Hex string containing ch, fg, & bg data.
+   */
+  private static readMinimalGlyphString(texture: Phaser.Textures.Texture) {
+    return texture.key.split(' ')[0] as `0x${string}`;
+  }
+
+  /**
+   * Map numeric id to texture.
+   */
+  private readonly textures = new Map<number, Phaser.Textures.Texture>();
+
+  /**
+   * Map hex string to numeric id.
+   */
+  private readonly texturesIndex = new Map<`0x${string}`, number>();
+
+  /**
+   * Track the number of times a numeric id has been added & removed.
+   */
+  private readonly idCounts = new Map<number, number>();
+
+  /**
+   * Current id count.
+   */
+  private idCount = 0;
+
+  /**
+   * Add texture to glyphset. If duplicate, id is maintained and count is
+   * increased.
+   * @param texture Texture generated by a glyph plugin.
+   * @returns The numeric id of this texture in the glyphset.
+   */
+  add(texture: Phaser.Textures.Texture) {
+    const hex = Glyphset.readMinimalGlyphString(texture);
+
+    if (this.texturesIndex.has(hex)) {
+      const id = this.texturesIndex.get(hex);
+      this.idCounts.set(id, this.idCounts.get(id) + 1);
+      return id;
+    }
+
+    const id = ++this.idCount;
+
+    this.textures.set(id, texture);
+    this.texturesIndex.set(hex, id);
+
+    if (!this.idCounts.has(id)) {
+      this.idCounts.set(id, 0);
+    }
+
+    this.idCounts.set(id, this.idCounts.get(id) + 1);
+
+    return id;
+  }
+
+  /**
+   * Clear glyphset data & state.
+   * @returns Reference to glyphset for further chaining.
+   */
+  clear() {
+    this.textures.clear();
+    this.texturesIndex.clear();
+    this.idCounts.clear();
+    this.idCount = 0;
+    return this;
+  }
+
+  /**
+   * Get texture referenced by specified ID.
+   * @param id Numeric texture ID.
+   * @returns Reference to texture, if it exists.
+   */
+  get(id: number) {
+    return this.textures.get(id);
+  }
+
+  /**
+   * Check if texture reference by specified ID exists in the glyphset.
+   * @param id Numeric texture ID.
+   * @returns Boolean value indicating existence within the glyphset.
+   */
+  has(id: number) {
+    return this.textures.has(id);
+  }
+
+  /**
+   * Remove texture reference by specified ID from glyphset. If this texture
+   * has been duplicated, texture is kept and ID count is decreased.
+   * @param id Numeric texture ID.
+   * @returns Reference to glyphset for further chaining.
+   */
+  remove(id: number) {
+    if (!this.textures.has(id)) {
+      return this;
+    }
+
+    const idCount = this.idCounts.get(id) - 1;
+
+    if (idCount <= 0) {
+      const texture = this.textures.get(id);
+      const hex = Glyphset.readMinimalGlyphString(texture);
+
+      this.textures.delete(id);
+      this.texturesIndex.delete(hex);
+      this.idCounts.delete(id);
+    } else {
+      this.idCounts.set(id, idCount);
+    }
+
+    return this;
+  }
+
+  /**
+   * Update textures contained within the glyphset on the fly using specified
+   * plugin, font, & force square ratio combination.
+   * @param glyphPlugin Glyph plugin to use.
+   * @param font Font to use.
+   * @param forceSquareRatio Force square ratio?
+   * @returns Reference to glyphset for further chaining.
+   */
+  update(glyphPlugin: GlyphPlugin, font: Font, forceSquareRatio: boolean) {
     const textures = this.textures;
 
-    const getTextureFromBuffer = this.glyphPlugin['getTextureFromBuffer'].bind(
-      this.glyphPlugin
-    ) as typeof this.glyphPlugin['getTextureFromBuffer'];
+    const getTextureFromBuffer = glyphPlugin['getTextureFromBuffer'].bind(
+      glyphPlugin
+    ) as typeof glyphPlugin['getTextureFromBuffer'];
 
-    for (const [key, cellTextures] of textures) {
-      const newCellTextures: Phaser.Textures.Texture[] = [];
-
-      cellTextures.forEach((tex) =>
-        newCellTextures.push(
-          getTextureFromBuffer(convertHexStringToBuffer(tex.key.split(' ')[0] as never), font, forceSquareRatio)
-        )
+    for (const [key, texture] of textures) {
+      textures.set(
+        key,
+        getTextureFromBuffer(convertHexStringToBuffer(Glyphset.readMinimalGlyphString(texture)), font, forceSquareRatio)
       );
-
-      textures.set(key, newCellTextures);
     }
 
     return this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export { Glyphmap } from './gameobjects/glyphmap';
 export type { GlyphPluginInitData } from './plugin';
 export { GlyphPlugin, GlyphPluginEvent } from './plugin';
 export type { CharLike, ColorLike, GlyphLike } from './shared';
+export { Font } from './shared';

--- a/src/shared.spec.ts
+++ b/src/shared.spec.ts
@@ -1,4 +1,4 @@
-import type { ColorLike, GlyphLike } from './shared';
+import { ColorLike, convertHexStringToBuffer, GlyphLike } from './shared';
 import {
   bytesPerColor,
   bytesPerChar,
@@ -226,6 +226,32 @@ describe('convertCharLikeToString', () => {
     const input = '#';
     const actual = convertCharLikeToString(input);
     const expected = '#';
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('convertHexStringToBuffer', () => {
+  it('is a function', () => {
+    const input = convertHexStringToBuffer;
+    const actual = typeof input;
+    const expected = 'function';
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('throws error when give hex string of uneven length', () => {
+    const input = '0xaa03f';
+    const actual = () => convertHexStringToBuffer(input);
+    const expected = `Invalid hex string: ${input}; must be an even number in length`;
+
+    expect(actual).toThrow(expected);
+  });
+
+  it('converts a hex string to a buffer', () => {
+    const input = '0xaa03fd';
+    const actual = convertHexStringToBuffer(input);
+    const expected = new Uint8Array([0xaa, 0x03, 0xfd]);
 
     expect(actual).toEqual(expected);
   });

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -236,6 +236,25 @@ export function convertCharLikeToString(charlike: CharLike) {
 }
 
 /**
+ *
+ * @param hex
+ * @returns
+ * @throws
+ */
+export function convertHexStringToBuffer(hex: `0x${string}`) {
+  if (hex.length % 2 !== 0) {
+    throw new Error(`Invalid hex string: ${hex}; must be an even number in length`);
+  }
+
+  return new Uint8Array(
+    hex
+      .slice(2)
+      .match(/.{1,2}/g)
+      .map((byte) => parseInt(byte, 16))
+  );
+}
+
+/**
  * Create internal buffer representation of specified glyphlikes.
  * @param glyphs Glyphlikes to create the buffer from.
  * @returns Uint8Array buffer containing all specified glyph data in Big-Endian

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -236,10 +236,11 @@ export function convertCharLikeToString(charlike: CharLike) {
 }
 
 /**
- *
- * @param hex
- * @returns
- * @throws
+ * Converts specified hex string to its corresponding buffer representation.
+ * @param hex Hex string to convert.
+ * @returns Buffer representation of specified hex string.
+ * @throws Error if specified hex string is not an even number in length.
+ * @internal
  */
 export function convertHexStringToBuffer(hex: `0x${string}`) {
   if (hex.length % 2 !== 0) {


### PR DESCRIPTION
Resolves #7 .

[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/kidthales/8783260504aa23bb1c4dd36f0ba3be01/raw/phaser3-glyph-plugin__heads_reduce-glyphmap-memory.json)](https://github.com/agogpixel/phaser3-glyph-plugin/tree/reduce-glyphmap-memory)